### PR TITLE
Environment construction

### DIFF
--- a/app/views/review_logs/index.html.slim
+++ b/app/views/review_logs/index.html.slim
@@ -5,7 +5,7 @@ article.flex.flex-col.justify-center.items-center
     - if @review_logs.present?
       ul.grid.grid-cols-3
         - @review_logs.each do |log|
-          li.w-full = link_to log.repository_name, review_log_path(log.repository_name), class: 'hover:bg-white px-4 py-2 rounded hover:text-slate-800 w-full inline-block transition-all'
+          li.w-full = link_to "#{log.repository_name}：#{log.review_contents.size}件のログ", '#', class: 'hover:bg-white px-4 py-2 rounded hover:text-slate-800 w-full inline-block transition-all'
     - else
       p.text-center まだレビューログがありません
 

--- a/app/views/shared/_headers.html.slim
+++ b/app/views/shared/_headers.html.slim
@@ -12,7 +12,6 @@
           ul.uk-dropdown-nav.uk-nav
             li
               = link_to 'リポジトリ一覧', repositories_path
-            li.uk-nav-divider
             li
               = link_to 'レビュー記録(α版)', review_logs_path
             li.uk-nav-divider

--- a/app/views/shared/_headers.html.slim
+++ b/app/views/shared/_headers.html.slim
@@ -14,6 +14,9 @@
               = link_to 'リポジトリ一覧', repositories_path
             li.uk-nav-divider
             li
+              = link_to 'レビュー記録(α版)', review_logs_path
+            li.uk-nav-divider
+            li
               = link_to 'ログアウト', logout_path, data: { turbo_method: :delete }
       - else
         = link_to 'GitHub Login', '/auth/github', data: { turbo: false }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
     post 'code_review', on: :member
     resources :review_logs, only: %i[create destroy]
   end
+  resources :review_logs, only: %i[index]
 end


### PR DESCRIPTION
# 概要

レビューログのあるリポジトリの一覧表示の実装を行いました。

## 内容

- [x] メニューのレビューログのリンクを踏むと localhost:3000/review_logsに遷移する
- [x] ヘッダーのアバターメニューにレビューログのリンクが追加されている
- [x] localhost:3000/review_logsでログの保存がなければ「ログの保存がありません」的な文言が表示される
[![Image from Gyazo](https://i.gyazo.com/f69e49f29647237e1cdd0f3acb65a213.png)](https://gyazo.com/f69e49f29647237e1cdd0f3acb65a213)
- [x] localhost:3000/review_logsでログの保存があれば、保存したログのあるリポジトリ一覧のリンクが表示される
[![Image from Gyazo](https://i.gyazo.com/5e4e4412bab59a0792f5ad4d94bb56f7.png)](https://gyazo.com/5e4e4412bab59a0792f5ad4d94bb56f7)

## 補足

「各リポジトリに何件のログがあるか合わせて表記」はリポジトリ名の隣に表記するように実装しております。
